### PR TITLE
Se agrega el campo createAtDate y se cambia el query `get_rework_history` para filtrar las fechas mediante createAtDate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,27 @@
-venv/
+# Carpetas y archivos de Python
 __pycache__/
+*.py[cod]
+*.pyo
+*.pyd
 *.pyc
-rework_data.json
+
+# Entorno virtual
+venv/
+.env
+.env.*
+
+# Archivos de configuración del sistema o IDE
+*.log
+*.sqlite3
+*.db
+*.swp
+.DS_Store
+.idea/
+.vscode/
+*.bak
+
+# Test
+tests/
+.coverage
+htmlcov/
+.tox/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ rework_percentage.txt
 # Sistema operativo
 .DS_Store
 Thumbs.db
+
+# environment variables
+*.env 
+*.env.development

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,26 @@
 # SCISA Benchmarks API
 
+## 0.3.0 - 09/05/2025
+
+### Resumen
+Se agrega un campo nuevo para poder dicernir entre el lapso del rework y cuando se creo el reporte. 
+Se añade tambien mejoras para el docker.
+
+### Fixed
+    - [220] Ahora al devoler el historico del rework se hace mediante el lapso del tiempo en el que se hizo el reporte, y no el lapso de tiempo del análisis.
+
+### Added
+    - [220] Se agrega un campo nuevo llamado createdAtDate como punto de partida del reporte.
+
+### Changed
+//
+### Deprecated
+//
+### Removed
+//
+### Security
+//
+
 ## 0.2.0-rc - 04/25/257
 
 ### Resumen

--- a/models/rework.py
+++ b/models/rework.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, DateTime
+from sqlalchemy import Column, Integer, String, Float, DateTime, Date
 from database import Base
 
 class ReworkDataDB(Base):
@@ -16,3 +16,4 @@ class ReworkDataDB(Base):
     modified_lines = Column(Integer)
     rework_lines = Column(Integer)
     rework_percentage = Column(Float)
+    createdAtDate = Column(Date)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scisa_benchmarks_api"
-version = "0.2.0"
+version = "0.3.0"
 description = "Api que maneja las diferentes benchmarks de los repositorios de SCISA"
 authors = [{ name = "Carlos Alberto Torres Cano", email = "carlos.torres@scisa.com.mx" }, {name="Abigail Morales Aquino", email="abigail.morales@scisa.com.mx"}]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "scisa_benchmarks_api"
 version = "0.2.0"
-description = "Un api que maneja las diferentes benchmarks de los repositorios de SCISA"
+description = "Api que maneja las diferentes benchmarks de los repositorios de SCISA"
 authors = [{ name = "Carlos Alberto Torres Cano", email = "carlos.torres@scisa.com.mx" }, {name="Abigail Morales Aquino", email="abigail.morales@scisa.com.mx"}]
 
-[urls]
+[project.urls]
 app_url = "https://rework-rate.scisa.com.mx"
 api_url = "https://api.rework-rate.scisa.com.mx/graphql"

--- a/resolvers/rework.py
+++ b/resolvers/rework.py
@@ -15,5 +15,6 @@ def convert_to_type(record: ReworkDataDB) -> ReworkDataType:
         modified_lines=record.modified_lines,
         rework_lines=record.rework_lines,
         rework_percentage=record.rework_percentage,
+        createdAtDate=record.createdAtDate,
     )
 

--- a/rework-rate.sh
+++ b/rework-rate.sh
@@ -1,11 +1,130 @@
 #!/bin/bash
 
+# ===================================================
 # Variables
+# ===================================================
 OUTPUT_CHANGES="rework_changes.txt"
 OUTPUT_SPECIFIC="specific_rework_changes.txt"
 OUTPUT_PERCENTAGE="rework_percentage.txt"
-EXCLUDED_FILES="azure-pipelines.yml CHANGELOG.md appsettings.json appsettings.*.json \ bin/ obj/ \*.csproj *.sln \wwwroot/ \Migrations/ \*.g.cs *.g.i.cs \*.designer.cs \*.razor.g.cs *.dll"
 DAYS=21
+EXCLUDED_FILES="\
+azure-pipelines.yml \
+CHANGELOG.md \
+appsettings.json \
+appsettings.*.json \
+bin/ \
+obj/ \
+*.csproj \
+*.sln \
+*.sln.docstates \
+*.rsuser \
+*.suo \
+*.user \
+*.userosscache \
+*.userprefs \
+mono_crash.* \
+*.dll \
+*.exe \
+*.pdb \
+*.cache \
+*.log \
+*.tmp \
+*.vspscc \
+*.vssscc \
+*.pidb \
+*.svclog \
+*.scc \
+*.ilk \
+*.meta \
+*.iobj \
+*.pch \
+*.ipdb \
+*.pgc \
+*.pgd \
+*.rsp \
+*.sbr \
+*.tlb \
+*.tli \
+*.tlh \
+*.tlog \
+*.VC.db \
+*.VC.VC.opendb \
+.vs/ \
+Logs/ \
+*.VisualState.xml \
+TestResult.xml \
+nunit-*.xml \
+BenchmarkDotNet.Artifacts/ \
+artifacts/ \
+*.coverage \
+*.coveragexml \
+*.code-workspace \
+node_modules/ \
+*.nupkg \
+*.snupkg \
+*.publishsettings \
+*.appx \
+*.appxbundle \
+*.appxupload \
+*.dbmdl \
+*.mdf \
+*.ldf \
+*.ndf \
+*.btp.cs \
+*.btm.cs \
+*.odx.cs \
+*.xsd.cs \
+*.designer.cs \
+*.razor.g.cs \
+*.g.cs \
+*.g.i.cs \
+*.tmp_proj \
+*.publish.xml \
+*.azurePubxml \
+*.pubxml \
+*.publishproj \
+PublishScripts/ \
+Generated\ Files/ \
+Generated_Code/ \
+wwwroot/ \
+Migrations/ \
+.vscode/ \
+.history/ \
+.idea/ \
+_ReSharper*/ \
+*.DotSettings.user \
+packages/ \
+*.bak \
+*_i.c \
+*_p.c \
+*_h.h \
+*.tss \
+*.jmconfig \
+OpenCover/ \
+FakesAssemblies/ \
+*.binlog \
+*.e2e \
+*.gpState \
+*.psess \
+*.vsp \
+*.vspx \
+*.sap \
+ClientBin/ \
+ServiceFabricBackup/ \
+*.rdl.data \
+*.rptproj.rsuser \
+*.bim.layout \
+*.bim_*.settings \
+*.rptproj.bak \
+.localhistory/ \
+.healthchecksdb/ \
+MigrationBackup/ \
+.publish/ \
+.publishxml/ \
+*.tmp.csproj \
+*.feature.cs \
+.config/ \
+"
 
 rm -f "$OUTPUT_CHANGES" "$OUTPUT_SPECIFIC" "$OUTPUT_PERCENTAGE"
 
@@ -88,7 +207,9 @@ else
     rework_percentage=$(awk "BEGIN {printf \"%.2f\", ($rework_lines/$total_lines)*100}")
 fi
 
+# ===================================================
 # Guardar el porcentaje de rework en el archivo
+# ===================================================
 echo "Resumen del análisis de Rework:" >> "$OUTPUT_PERCENTAGE"
 echo "---------------------------------" >> "$OUTPUT_PERCENTAGE"
 echo "REWORK %$rework_percentage" >> "$OUTPUT_PERCENTAGE"
@@ -123,7 +244,9 @@ echo "Enviando datos a la API..."
 AUTHOR=$(echo "$AUTHOR" | sed 's/\\/\\\\/g')
 REPO_URL=$(echo "$REPO_URL" | sed 's/\\/\\\\/g')
 
-# Construcción del payload GraphQL
+# ===================================================
+# Construcción del payload 
+# ===================================================
 graphql_query=$(cat <<EOF
 {
   "query": "mutation CreateReworkData(\$data: ReworkDataInput!) { createReworkData(data: \$data) { id repoUrl prNumber author } }",
@@ -134,6 +257,7 @@ graphql_query=$(cat <<EOF
       "author": "$AUTHOR",
       "prApprover": "$APPROVER",
       "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+      "createdAtDate": "$(date -u +"%Y-%m-%d")",
       "totalCommits": $total_commits,
       "periodStart": "$START_DATE",
       "periodEnd": "$END_DATE",
@@ -146,11 +270,15 @@ graphql_query=$(cat <<EOF
 EOF
 )
 
+# ===================================================
 # Mostrar el JSON para verificación
+# ===================================================
 echo "Enviando a GraphQL:"
 echo "$graphql_query"
 
+# ===================================================
 # Enviar la petición al endpoint GraphQL
+# ===================================================
 curl -X POST https://api.rework-rate.scisa.com.mx/graphql \
     -H "Content-Type: application/json" \
     --data-raw "$graphql_query"

--- a/schemas/rework_rate/rework_rate_query.py
+++ b/schemas/rework_rate/rework_rate_query.py
@@ -45,8 +45,8 @@ class Query:
         if start_date and end_date:
             query = query.filter(
                 and_(
-                    ReworkDataDB.period_start >= start_date,
-                    ReworkDataDB.period_start <= end_date
+                    ReworkDataDB.createdAtDate >= start_date,
+                    ReworkDataDB.createdAtDate <= end_date
                 )
             )
         query = query.order_by(ReworkDataDB.period_start.asc())

--- a/schemas/rework_rate/rework_rate_types.py
+++ b/schemas/rework_rate/rework_rate_types.py
@@ -15,6 +15,7 @@ class ReworkDataType:
     modified_lines: int
     rework_lines: int
     rework_percentage: float
+    createdAtDate: datetime
 
 @strawberry.input
 class ReworkDataInput:
@@ -29,6 +30,7 @@ class ReworkDataInput:
     modified_lines: int
     rework_lines: int
     rework_percentage: float
+    createdAtDate: datetime
 
 @strawberry.type
 class RepoUrlType:


### PR DESCRIPTION
## 0.3.0 - 09/05/2025

### Resumen
Se agrega un campo nuevo para poder dicernir entre el lapso del rework y cuando se creo el reporte. 
Se añade tambien mejoras para el docker.

### Fixed
    - [220] Ahora al devoler el historico del rework se hace mediante el lapso del tiempo en el que se hizo el reporte, y no el lapso de tiempo del análisis.

### Added
    - [220] Se agrega un campo nuevo llamado createdAtDate como punto de partida del reporte.

### Changed
//
### Deprecated
//
### Removed
//
### Security
//
